### PR TITLE
Add default rules for ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hearsay Social's base JavaScript style.
 
-## Ussage
+## Usage
 
 Install this package, and eslint:
 
@@ -12,5 +12,22 @@ Add this `extends` value to the root level of your `.eslintrc`:
 
     {
         "extends": "eslint-config-hss",
+        // ...
+    }
+
+## Additional Configurations
+
+ESLint allows you to "extend" from multiple base configurations. If you use any
+of the below features, you may add these additional specialized base
+configurations. Each configuration contains only the rules associated with the
+given feature so you may combine them as your project demands.
+
+### ES6
+
+    {
+        "extends": [
+            "eslint-config-hss",
+            "eslint-config-hss/es6"
+        ],
         // ...
     }

--- a/es6.js
+++ b/es6.js
@@ -1,0 +1,27 @@
+module.exports = {
+    "rules": {
+        "arrow-spacing": "error",
+        "constructor-super": "error",
+        "generator-star-spacing": "error",
+        "no-class-assign": "error",
+        "no-confusing-arrow": "error",
+        "no-const-assign": "error",
+        "no-dupe-class-members": "error",
+        "no-duplicate-imports": "error",
+        "no-new-symbol": "error",
+        "no-restricted-imports": "error",
+        "no-this-before-super": "error",
+        "no-useless-computed-key": "error",
+        "no-useless-constructor": "error",
+        "no-useless-rename": "error",
+        "no-var": "error",
+        "prefer-const": "error",
+        "prefer-reflect": "error",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error",
+        "require-yield": "error",
+        "rest-spread-spacing": "error",
+        "template-curly-spacing": "error",
+        "yield-star-spacing": "error"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hss",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Default style for JavaScript at Hearsay Social",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We test-ran these rules with the Hearsay Messages Web Client project. They
seemed to work well there, so think they are ready for adoption by other
projects.