### PR TITLE
Revert indentation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,3 @@ given feature so you may combine them as your project demands.
         ],
         // ...
     }
-
-## Changelog
-
-### 3.2.0
-
-* Begin enforcing indentation. (#7)

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
         "curly": "error",
         "eqeqeq": "error",
         "guard-for-in": "error",
-        "indent": ["error", 4, { "SwitchCase": 1 }],
+        "indent": ["off", 4, { "SwitchCase": 1 }],
         "linebreak-style": ["error", "unix"],
         "max-len": ["error", 120, 4, {"ignoreComments": true}],
         "max-statements": ["warn", 50],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hss",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Default style for JavaScript at Hearsay Social",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This should have gone out on a new major version since it will introduce
new failures.

Reverting here with a new version three tag. Other repos tagged to the
3.*.* version should go back to not enforcing this rule. I'll follow-up
with another PR that adds the rule back and bumps us to v4.0.0.