### PR TITLE
Disable max-statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ module.exports = {
         "guard-for-in": "error",
         "linebreak-style": ["error", "unix"],
         "max-len": ["error", 120, 4, {"ignoreComments": true}],
-        "max-statements": ["warn", 50],
         "new-cap": ["error", {"capIsNew": false, "properties": false}],
         "no-caller": "error",
         "no-cond-assign": "error",


### PR DESCRIPTION
This rule falls into a trap. Because the person who first triggers the warning
is not necessarily individually responsible for causing it, _and_ fixing this
kind of issue can be non-trivial, these warnings tend to go unfixed.

To reduce warning noise, and thus increase the value of other warnings,
I propose we remove this warning.