### PR TITLE
allow async arrows to have a space without error

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,11 @@ module.exports = {
         "no-useless-rename": "error",
         "radix": ["error", "always"],
         "semi": ["error", "always"],
-        "space-before-function-paren": ["error", "never"],
+        "space-before-function-paren": ["error", {
+            "anonymous": "never",
+            "named": "never",
+            "asyncArrow": "always"
+        }],
         "space-infix-ops": "error",
         "use-isnan": "error",
         "valid-typeof": "error"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-hss",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Default style for JavaScript at Hearsay Social",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Decided to use this config for a new sites project and noticed that it throws on `async () => ...`.

/review @captbaritone @jeebay @alexritchey @Morgantheplant @fullstackhacker @mnugumanova 